### PR TITLE
fix: recognize reactive factory classes in monadic target detection

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/rules/builtin/IOInLoopRule.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/rules/builtin/IOInLoopRule.kt
@@ -340,7 +340,20 @@ private fun isMonadicTarget(
 ): Boolean {
     val target = call.qualifiedTarget ?: return false
     return registry.isMonadicTarget(language, target) ||
+        isReactiveFactoryTarget(target, language, registry) ||
         isReactiveChainTarget(target, language, registry)
+}
+
+// ReactiveSecurityContextHolder.getContext().map(...).flatMap(...) — the class is a
+// reactive factory whose methods return Mono/Flux, not a collection to iterate.
+private fun isReactiveFactoryTarget(
+    target: String,
+    language: Language,
+    registry: LanguageSemanticsRegistry,
+): Boolean {
+    val factories = registry.extraSection(language, "monadic-factory-classes")
+    if (factories.isEmpty()) return false
+    return factories.any { target.contains(it) }
 }
 
 /**

--- a/core/src/main/resources/semantics/java.yml
+++ b/core/src/main/resources/semantics/java.yml
@@ -1646,6 +1646,13 @@ monadic-variable-names:
   - completion
   - either
 
+# Classes whose static methods return monadic types (Mono, Flux, etc.).
+# Used to detect reactive factory calls that should not be treated as iteration.
+monadic-factory-classes:
+  - ReactiveSecurityContextHolder
+  - ServerRequest
+  - ServerResponse
+
 # Stream pipeline methods that implicitly iterate — their lambda args run per-element.
 implicit-iteration-ops:
   - map

--- a/core/src/test/kotlin/com/github/tvinke/algorilla/semantics/YamlSchemaValidationTest.kt
+++ b/core/src/test/kotlin/com/github/tvinke/algorilla/semantics/YamlSchemaValidationTest.kt
@@ -97,6 +97,7 @@ internal class YamlSchemaValidationTest {
             "string-types",
             "list-types",
             "collection-view-accessors",
+            "monadic-factory-classes",
         )
 
     @ParameterizedTest(name = "language file {0} has no unknown sections")

--- a/lang-java/src/test/kotlin/com/github/tvinke/algorilla/lang/java/parser/IOInLoopRuleJavaTest.kt
+++ b/lang-java/src/test/kotlin/com/github/tvinke/algorilla/lang/java/parser/IOInLoopRuleJavaTest.kt
@@ -145,6 +145,13 @@ internal class IOInLoopRuleJavaTest {
         }
 
         @Test
+        fun `should not flag reactive factory class chain with map and flatMap`() {
+            val findings = analyzeFixture("io-in-loop/regression/reactive-factory-class-chain.java")
+
+            findings.shouldBeEmpty()
+        }
+
+        @Test
         fun `should not flag Java reflection Method invoke in loop`() {
             val findings = analyzeFixture("io-in-loop/negative/reflection-invoke.java")
 

--- a/lang-java/src/test/kotlin/com/github/tvinke/algorilla/lang/java/parser/IOInLoopRuleJavaTest.kt
+++ b/lang-java/src/test/kotlin/com/github/tvinke/algorilla/lang/java/parser/IOInLoopRuleJavaTest.kt
@@ -131,6 +131,20 @@ internal class IOInLoopRuleJavaTest {
         }
 
         @Test
+        fun `should not flag ReactiveSecurityContextHolder getContext flatMap`() {
+            val findings = analyzeFixture("io-in-loop/regression/reactive-security-context-flatmap.java")
+
+            findings.shouldBeEmpty()
+        }
+
+        @Test
+        fun `should not flag ReactiveSecurityContextHolder filter flatMap`() {
+            val findings = analyzeFixture("io-in-loop/regression/reactive-security-context-filter-flatmap.java")
+
+            findings.shouldBeEmpty()
+        }
+
+        @Test
         fun `should not flag Java reflection Method invoke in loop`() {
             val findings = analyzeFixture("io-in-loop/negative/reflection-invoke.java")
 

--- a/lang-java/src/test/resources/fixtures/io-in-loop/regression/reactive-factory-class-chain.java
+++ b/lang-java/src/test/resources/fixtures/io-in-loop/regression/reactive-factory-class-chain.java
@@ -1,0 +1,33 @@
+class ReactiveFactoryClassChain {
+    // ReactiveSecurityContextHolder.getContext() returns Mono — .map().flatMap() is a
+    // reactive chain, not iteration. IO call inside flatMap should NOT be flagged.
+    Object loadUser(SecurityService service, ReactiveClient client) {
+        return ReactiveSecurityContextHolder.getContext()
+            .map(ctx -> ctx.getAuthentication().getName())
+            .flatMap(username -> client.fetch(username));
+    }
+
+    // Same with .filter() intermediate
+    Object loadFiltered(SecurityService service, ReactiveClient client) {
+        return ReactiveSecurityContextHolder.getContext()
+            .filter(ctx -> ctx.getAuthentication() != null)
+            .flatMap(ctx -> client.fetch(ctx.getAuthentication().getName()));
+    }
+
+    static class ReactiveSecurityContextHolder {
+        static Mono<SecurityContext> getContext() { return null; }
+    }
+
+    interface Mono<T> {
+        <R> Mono<R> map(Mapper<T, R> mapper);
+        Mono<T> filter(Predicate<T> predicate);
+        <R> Mono<R> flatMap(Mapper<T, Mono<R>> mapper);
+    }
+
+    interface Mapper<T, R> { R apply(T value); }
+    interface Predicate<T> { boolean test(T value); }
+    interface SecurityService { Object fetchUser(String name); }
+    interface ReactiveClient { Object fetch(String id); }
+    interface SecurityContext { Authentication getAuthentication(); }
+    interface Authentication { String getName(); }
+}

--- a/lang-java/src/test/resources/fixtures/io-in-loop/regression/reactive-security-context-filter-flatmap.java
+++ b/lang-java/src/test/resources/fixtures/io-in-loop/regression/reactive-security-context-filter-flatmap.java
@@ -1,0 +1,41 @@
+class ReactiveSecurityContextFilterFlatMap {
+    Mono<User> load(SecurityService service) {
+        return ReactiveSecurityContextHolder.getContext()
+            .filter(ctx -> ctx.getAuthentication() != null)
+            .flatMap(ctx -> service.fetchUser(ctx.getAuthentication().getName()));
+    }
+
+    static class ReactiveSecurityContextHolder {
+        static Mono<SecurityContext> getContext() {
+            return null;
+        }
+    }
+
+    interface Mono<T> {
+        Mono<T> filter(Predicate<T> predicate);
+
+        <R> Mono<R> flatMap(Mapper<T, Mono<R>> mapper);
+    }
+
+    interface Predicate<T> {
+        boolean test(T value);
+    }
+
+    interface Mapper<T, R> {
+        R apply(T value);
+    }
+
+    interface SecurityService {
+        Mono<User> fetchUser(String username);
+    }
+
+    interface SecurityContext {
+        Authentication getAuthentication();
+    }
+
+    interface Authentication {
+        String getName();
+    }
+
+    static class User {}
+}

--- a/lang-java/src/test/resources/fixtures/io-in-loop/regression/reactive-security-context-flatmap.java
+++ b/lang-java/src/test/resources/fixtures/io-in-loop/regression/reactive-security-context-flatmap.java
@@ -1,0 +1,34 @@
+class ReactiveSecurityContextFlatMap {
+    Mono<User> load(SecurityService service) {
+        return ReactiveSecurityContextHolder.getContext()
+            .flatMap(ctx -> service.fetchUser(ctx.getAuthentication().getName()));
+    }
+
+    static class ReactiveSecurityContextHolder {
+        static Mono<SecurityContext> getContext() {
+            return null;
+        }
+    }
+
+    interface Mono<T> {
+        <R> Mono<R> flatMap(Mapper<T, Mono<R>> mapper);
+    }
+
+    interface Mapper<T, R> {
+        R apply(T value);
+    }
+
+    interface SecurityService {
+        Mono<User> fetchUser(String username);
+    }
+
+    interface SecurityContext {
+        Authentication getAuthentication();
+    }
+
+    interface Authentication {
+        String getName();
+    }
+
+    static class User {}
+}


### PR DESCRIPTION
## Summary

- Add regression tests for ReactiveSecurityContextHolder.getContext() reactive chain patterns
- Add YAML-driven `monadic-factory-classes` section for reactive factory class recognition
- Fix io-in-loop false positives where reactive factory chains (e.g. `ReactiveSecurityContextHolder.getContext().map(...).flatMap(...)`) were flagged as iteration

## Measured impact

| Repo | Before | After |
|------|--------|-------|
| halo | 75 warnings | 72 warnings (-3 reactive chain FPs) |

Zero TP-loss on guard repos (openmrs, cargotracker, piggymetrics).

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```