### PR TITLE
feat: lifecycle annotation extraction and demotion

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/engine/AnalysisEngine.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/engine/AnalysisEngine.kt
@@ -79,9 +79,10 @@ public class AnalysisEngine(
         val deduplicated = applySubsumption(rawFindings, rules)
         val vendoredDemoted = demoteVendoredCode(deduplicated)
         val constructorDemoted = demoteConstructorFindings(vendoredDemoted, irTrees)
+        val lifecycleDemoted = demoteLifecycleFindings(constructorDemoted, irTrees, registry)
         val fileLanguages = irTrees.mapValues { (_, root) -> root.language }
         val ruleIndex = rules.associateBy { it.id }
-        val confidenceAdjusted = adjustConfidence(constructorDemoted, fileLanguages, ruleIndex)
+        val confidenceAdjusted = adjustConfidence(lifecycleDemoted, fileLanguages, ruleIndex)
         val suppressed = SuppressionFilter().filter(confidenceAdjusted, irTrees, aliasIndex)
         val freshFindings = renderCodeSuggestions(suppressed, finalContexts, fileLanguages)
 

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/engine/FindingPostProcessor.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/engine/FindingPostProcessor.kt
@@ -1,5 +1,6 @@
 package com.github.tvinke.algorilla.engine
 
+import com.github.tvinke.algorilla.model.ClassNode
 import com.github.tvinke.algorilla.model.Confidence
 import com.github.tvinke.algorilla.model.FileRoot
 import com.github.tvinke.algorilla.model.FunctionDecl
@@ -7,6 +8,7 @@ import com.github.tvinke.algorilla.model.IRNode
 import com.github.tvinke.algorilla.model.Language
 import com.github.tvinke.algorilla.rules.Finding
 import com.github.tvinke.algorilla.rules.Rule
+import com.github.tvinke.algorilla.semantics.LanguageSemanticsRegistry
 import com.github.tvinke.algorilla.util.findDescendants
 
 /**
@@ -70,6 +72,72 @@ internal fun demoteConstructorFindings(
             finding
         }
     }
+}
+
+/**
+ * Demotes findings in lifecycle/init methods to LOW confidence.
+ * Lifecycle methods (@PostConstruct, @Bean, InitializingBean.afterPropertiesSet) run at
+ * startup or configuration time — findings there are technically correct but not actionable.
+ */
+internal fun demoteLifecycleFindings(
+    findings: List<Finding>,
+    irTrees: Map<String, FileRoot>,
+    registry: LanguageSemanticsRegistry,
+): List<Finding> {
+    val lifecycleRanges = mutableMapOf<String, MutableList<IntRange>>()
+    for ((_, fileRoot) in irTrees) {
+        val language = fileRoot.language
+        val methodAnnotations = registry.extraSection(language, "lifecycle-method-annotations")
+        val lifecycleInterfaces = registry.extraSection(language, "lifecycle-interfaces")
+        if (methodAnnotations.isEmpty() && lifecycleInterfaces.isEmpty()) continue
+
+        // Build a set of known lifecycle interface callback method names
+        val interfaceCallbacks = buildInterfaceCallbacks(lifecycleInterfaces)
+
+        for (fn in fileRoot.findDescendants<FunctionDecl>()) {
+            val isLifecycleAnnotated = fn.annotations.any { it in methodAnnotations }
+            val isInterfaceCallback = fn.name in interfaceCallbacks && isInLifecycleClass(fn, fileRoot, lifecycleInterfaces)
+            if (isLifecycleAnnotated || isInterfaceCallback) {
+                val start = fn.location.line
+                val end = maxLineOf(fn)
+                lifecycleRanges.getOrPut(fileRoot.filePath) { mutableListOf() }.add(start..end)
+            }
+        }
+    }
+    if (lifecycleRanges.isEmpty()) return findings
+    return findings.map { finding ->
+        val ranges = lifecycleRanges[finding.location.file]
+        if (ranges != null && ranges.any { finding.location.line in it }) {
+            finding.copy(confidence = Confidence.LOW)
+        } else {
+            finding
+        }
+    }
+}
+
+private val KNOWN_CALLBACKS =
+    mapOf(
+        "InitializingBean" to "afterPropertiesSet",
+        "DisposableBean" to "destroy",
+        "SmartLifecycle" to "start",
+        "SmartInitializingSingleton" to "afterSingletonsInstantiated",
+    )
+
+private fun buildInterfaceCallbacks(lifecycleInterfaces: Set<String>): Set<String> =
+    KNOWN_CALLBACKS.entries
+        .filter { it.key in lifecycleInterfaces }
+        .map { it.value }
+        .toSet()
+
+private fun isInLifecycleClass(
+    fn: FunctionDecl,
+    fileRoot: FileRoot,
+    lifecycleInterfaces: Set<String>,
+): Boolean {
+    val declaringClass = fn.declaringClass ?: return false
+    return fileRoot
+        .findDescendants<ClassNode>()
+        .any { it.name == declaringClass && it.supertypes.any { st -> st in lifecycleInterfaces } }
 }
 
 /** Recursively finds the maximum source line in an IR subtree. */

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/model/IRNode.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/model/IRNode.kt
@@ -150,6 +150,8 @@ public data class FunctionDecl(
     var executionContext: ExecutionContext = ExecutionContext.SINGLE,
     var parameterFlows: List<ParameterFlow> = emptyList(),
     var isRecursive: Boolean = false,
+    /** Simple annotation names on this method, e.g. ["PostConstruct", "Bean"]. */
+    val annotations: List<String> = emptyList(),
     override val location: SourceLocation,
     override val children: List<IRNode>,
 ) : IRNode
@@ -231,6 +233,8 @@ public data class ClassNode(
     val name: String,
     /** Supertypes (implements/extends), generics stripped. */
     val supertypes: List<String> = emptyList(),
+    /** Simple annotation names on this class, e.g. ["Component", "ApplicationScoped"]. */
+    val annotations: List<String> = emptyList(),
     override val location: SourceLocation,
     override val children: List<IRNode>,
 ) : IRNode

--- a/core/src/main/resources/semantics/frameworks/spring.yml
+++ b/core/src/main/resources/semantics/frameworks/spring.yml
@@ -215,3 +215,14 @@ io-method-candidates:
   - deleteAllInBatch
   - deleteAllByIdInBatch
   - flush
+
+lifecycle-method-annotations:
+  - PostConstruct
+  - Bean
+  - EventListener
+
+lifecycle-interfaces:
+  - InitializingBean
+  - SmartLifecycle
+  - DisposableBean
+  - SmartInitializingSingleton

--- a/core/src/main/resources/semantics/java.yml
+++ b/core/src/main/resources/semantics/java.yml
@@ -1653,6 +1653,16 @@ monadic-factory-classes:
   - ServerRequest
   - ServerResponse
 
+# Method annotations indicating lifecycle/startup methods — findings demoted to LOW.
+lifecycle-method-annotations:
+  - PostConstruct
+  - PreDestroy
+
+# Interfaces whose callback methods are lifecycle/startup — findings demoted to LOW.
+lifecycle-interfaces:
+  - InitializingBean
+  - DisposableBean
+
 # Stream pipeline methods that implicitly iterate — their lambda args run per-element.
 implicit-iteration-ops:
   - map

--- a/core/src/test/kotlin/com/github/tvinke/algorilla/engine/LifecycleDemotionTest.kt
+++ b/core/src/test/kotlin/com/github/tvinke/algorilla/engine/LifecycleDemotionTest.kt
@@ -1,0 +1,146 @@
+package com.github.tvinke.algorilla.engine
+
+import com.github.tvinke.algorilla.engine.demoteLifecycleFindings
+import com.github.tvinke.algorilla.model.ClassNode
+import com.github.tvinke.algorilla.model.Confidence
+import com.github.tvinke.algorilla.model.FileRoot
+import com.github.tvinke.algorilla.model.FunctionDecl
+import com.github.tvinke.algorilla.model.Language
+import com.github.tvinke.algorilla.model.Severity
+import com.github.tvinke.algorilla.model.SourceLocation
+import com.github.tvinke.algorilla.rules.Finding
+import com.github.tvinke.algorilla.semantics.LanguageSemanticsRegistry
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class LifecycleDemotionTest {
+    private val registry = LanguageSemanticsRegistry.loadDefaults()
+    private val loc = SourceLocation("Test.java", 1, 1)
+
+    private fun finding(
+        line: Int,
+        confidence: Confidence = Confidence.MEDIUM,
+    ) = Finding(
+        ruleId = "io-in-loop",
+        ruleName = "IO in Loop",
+        severity = Severity.WARNING,
+        location = SourceLocation("Test.java", line, 1),
+        message = "test",
+        suggestions = emptyList(),
+        confidence = confidence,
+        evidence = emptyList(),
+    )
+
+    private fun fn(
+        name: String,
+        line: Int,
+        endLine: Int,
+        annotations: List<String> = emptyList(),
+        declaringClass: String? = null,
+    ) = FunctionDecl(
+        name = name,
+        qualifiedName = "Test.$name",
+        parameters = emptyList(),
+        annotations = annotations,
+        declaringClass = declaringClass,
+        location = SourceLocation("Test.java", line, 1),
+        children =
+            listOf(
+                FunctionDecl(
+                    name = "inner",
+                    qualifiedName = "inner",
+                    parameters = emptyList(),
+                    location = SourceLocation("Test.java", endLine, 1),
+                    children = emptyList(),
+                ),
+            ),
+    )
+
+    @Nested
+    inner class MethodAnnotationDemotion {
+        @Test
+        fun `should demote findings inside @PostConstruct method to LOW`() {
+            val initFn = fn("initialize", 10, 20, annotations = listOf("PostConstruct"))
+            val fileRoot = FileRoot("Test.java", Language.JAVA, loc, listOf(initFn))
+            val findings = listOf(finding(15, Confidence.MEDIUM))
+
+            val result = demoteLifecycleFindings(findings, mapOf("Test.java" to fileRoot), registry)
+
+            result.first().confidence shouldBe Confidence.LOW
+        }
+
+        @Test
+        fun `should demote findings inside @Bean method to LOW`() {
+            val beanFn = fn("createService", 10, 20, annotations = listOf("Bean"))
+            val fileRoot = FileRoot("Test.java", Language.JAVA, loc, listOf(beanFn))
+            val findings = listOf(finding(15, Confidence.HIGH))
+
+            val result = demoteLifecycleFindings(findings, mapOf("Test.java" to fileRoot), registry)
+
+            result.first().confidence shouldBe Confidence.LOW
+        }
+
+        @Test
+        fun `should NOT demote findings in unannotated methods`() {
+            val regularFn = fn("processRequest", 10, 20)
+            val fileRoot = FileRoot("Test.java", Language.JAVA, loc, listOf(regularFn))
+            val findings = listOf(finding(15, Confidence.MEDIUM))
+
+            val result = demoteLifecycleFindings(findings, mapOf("Test.java" to fileRoot), registry)
+
+            result.first().confidence shouldBe Confidence.MEDIUM
+        }
+
+        @Test
+        fun `should NOT demote findings for non-lifecycle annotations`() {
+            val overrideFn = fn("toString", 10, 20, annotations = listOf("Override"))
+            val fileRoot = FileRoot("Test.java", Language.JAVA, loc, listOf(overrideFn))
+            val findings = listOf(finding(15, Confidence.MEDIUM))
+
+            val result = demoteLifecycleFindings(findings, mapOf("Test.java" to fileRoot), registry)
+
+            result.first().confidence shouldBe Confidence.MEDIUM
+        }
+    }
+
+    @Nested
+    inner class InterfaceCallbackDemotion {
+        @Test
+        fun `should demote findings inside afterPropertiesSet when class implements InitializingBean`() {
+            val afterPropsFn = fn("afterPropertiesSet", 10, 20, declaringClass = "MyService")
+            val classNode =
+                ClassNode(
+                    name = "MyService",
+                    supertypes = listOf("InitializingBean"),
+                    location = loc,
+                    children = listOf(afterPropsFn),
+                )
+            val fileRoot = FileRoot("Test.java", Language.JAVA, loc, listOf(classNode))
+            val findings = listOf(finding(15, Confidence.MEDIUM))
+
+            val result = demoteLifecycleFindings(findings, mapOf("Test.java" to fileRoot), registry)
+
+            result.first().confidence shouldBe Confidence.LOW
+        }
+
+        @Test
+        fun `should NOT demote regular methods even when class implements InitializingBean`() {
+            val regularFn = fn("processRequest", 30, 40, declaringClass = "MyService")
+            val afterPropsFn = fn("afterPropertiesSet", 10, 20, declaringClass = "MyService")
+            val classNode =
+                ClassNode(
+                    name = "MyService",
+                    supertypes = listOf("InitializingBean"),
+                    location = loc,
+                    children = listOf(afterPropsFn, regularFn),
+                )
+            val fileRoot = FileRoot("Test.java", Language.JAVA, loc, listOf(classNode))
+            val findings = listOf(finding(35, Confidence.MEDIUM))
+
+            val result = demoteLifecycleFindings(findings, mapOf("Test.java" to fileRoot), registry)
+
+            result.first().confidence shouldBe Confidence.MEDIUM
+        }
+    }
+}

--- a/core/src/test/kotlin/com/github/tvinke/algorilla/semantics/YamlSchemaValidationTest.kt
+++ b/core/src/test/kotlin/com/github/tvinke/algorilla/semantics/YamlSchemaValidationTest.kt
@@ -98,6 +98,8 @@ internal class YamlSchemaValidationTest {
             "list-types",
             "collection-view-accessors",
             "monadic-factory-classes",
+            "lifecycle-method-annotations",
+            "lifecycle-interfaces",
         )
 
     @ParameterizedTest(name = "language file {0} has no unknown sections")

--- a/lang-java/src/main/kotlin/com/github/tvinke/algorilla/lang/java/parser/JavaLanguageParser.kt
+++ b/lang-java/src/main/kotlin/com/github/tvinke/algorilla/lang/java/parser/JavaLanguageParser.kt
@@ -107,10 +107,12 @@ internal class JavaIRVisitor(
         enclosingClass = prev
         if (className == null) return result
         val supertypes = extractSupertypes(ctx)
+        val annotations = extractClassAnnotations(ctx)
         return listOf(
             ClassNode(
                 name = className,
                 supertypes = supertypes,
+                annotations = annotations,
                 location = locationOf(ctx),
                 children = result,
             ),
@@ -166,6 +168,7 @@ internal class JavaIRVisitor(
                 ?.typeType()
                 ?.text
                 ?.simplifyGenericType()
+        val annotations = extractMethodAnnotations(ctx)
 
         return listOf(
             FunctionDecl(
@@ -174,6 +177,7 @@ internal class JavaIRVisitor(
                 parameters = params,
                 declaringClass = enclosingClass,
                 returnType = returnType,
+                annotations = annotations,
                 location = loc,
                 children = body,
             ),
@@ -468,6 +472,31 @@ internal class JavaIRVisitor(
         }
 
         return params
+    }
+
+    /** Extracts simple annotation names from classBodyDeclaration modifiers (method-level). */
+    private fun extractMethodAnnotations(ctx: JavaParser.MethodDeclarationContext): List<String> {
+        val classBodyDecl = ctx.parent?.parent as? JavaParser.ClassBodyDeclarationContext ?: return emptyList()
+        return classBodyDecl.modifier().mapNotNull { mod ->
+            mod
+                .classOrInterfaceModifier()
+                ?.annotation()
+                ?.qualifiedName()
+                ?.text
+                ?.substringAfterLast('.')
+        }
+    }
+
+    /** Extracts simple annotation names from typeDeclaration modifiers (class-level). */
+    private fun extractClassAnnotations(ctx: JavaParser.ClassDeclarationContext): List<String> {
+        val typeDecl = ctx.parent as? JavaParser.TypeDeclarationContext ?: return emptyList()
+        return typeDecl.classOrInterfaceModifier().mapNotNull { mod ->
+            mod
+                .annotation()
+                ?.qualifiedName()
+                ?.text
+                ?.substringAfterLast('.')
+        }
     }
 
     private fun visitArgNodes(methodCall: JavaParser.MethodCallContext): List<IRNode> {


### PR DESCRIPTION
## Summary

First capability slice for Lijn B: lifecycle/init annotation awareness in the IR.

- Add `annotations: List<String>` to FunctionDecl and ClassNode in IR model
- Java parser extracts simple annotation names from method and class declarations
- YAML-driven lifecycle demotion: `lifecycle-method-annotations` and `lifecycle-interfaces` sections
- Post-processing `demoteLifecycleFindings()` demotes findings in @PostConstruct, @Bean, @EventListener methods and InitializingBean callbacks to LOW confidence

**Scope restriction:** Only method-level annotations and interface callbacks trigger demotion. Class-level stereotypes (@Component etc.) are extracted into IR but NOT used as demotion triggers.

**@Scheduled explicitly excluded** — caught by TP-guard on piggymetrics (scheduled methods run repeatedly and may contain actionable findings).

## Measured impact

Correctness-winner, not yet a fitness-winner:

| Repo | Before | After | Notes |
|------|--------|-------|-------|
| thingsboard | 201 warnings | 199 | -2 lifecycle FPs demoted |
| apollo | 70 warnings | 64 | -6 lifecycle FPs demoted |
| piggymetrics | 1 warning | 1 | TP preserved (@Scheduled excluded) |
| openmrs-core | 198 | 198 | Stable |
| cargotracker | 2 | 2 | Stable |

First-5 precision unchanged — remaining FPs are transitive lifecycle (called FROM @PostConstruct, not annotated themselves). That requires call-graph propagation (V4, future work).

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```