### PR TITLE
fix: recognize record accessor in string target detection

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/lang/java/parser/MethodClassification.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/lang/java/parser/MethodClassification.kt
@@ -328,7 +328,8 @@ public fun isStringTarget(
     return registry.stringIndicators(language).any { targetText.contains(it) } ||
         registry.stringNameSuffixes(language).any { suffix ->
             val getterSuffix = suffix.replaceFirstChar { it.uppercaseChar() }
-            targetText.contains(".get$getterSuffix(")
+            targetText.contains(".get$getterSuffix(") ||
+                targetText.contains(".$suffix(") // record accessor: .version(, .name(
         } ||
         registry.stringNameSuffixes(language).any { targetText.endsWith(it) } ||
         extractVariableName(targetText, language) in registry.stringExactNames(language)

--- a/core/src/main/resources/semantics/java.yml
+++ b/core/src/main/resources/semantics/java.yml
@@ -1016,6 +1016,10 @@ string-name-suffixes:
   - spec
   - Tag
   - tag
+  - Version
+  - version
+  - Series
+  - series
 
 # String detection: exact variable names almost always referring to Strings.
 string-exact-names:


### PR DESCRIPTION
## Summary

- Extend `isStringTarget()` to recognize Java record accessors (`.version(`, `.name(`) alongside JavaBean getters (`.getVersion(`, `.getName(`)
- Add `version/Version` and `series/Series` to `string-name-suffixes` in java.yml

## Discovery

Found via discovery campaign (cycle 10): Dependency-Track's `OsDistribution.version().contains(".")` was flagged as a collection lookup because `version()` is a record accessor without `get` prefix.

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```

Zero TP-loss on guard repos.