### PR TITLE
fix: restrict HIGH promotion passthrough to MEDIUM-default rules

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/engine/FindingPostProcessor.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/engine/FindingPostProcessor.kt
@@ -170,12 +170,13 @@ internal fun adjustConfidence(
         val ceiling = rule?.defaultConfidence ?: Confidence.MEDIUM
 
         // Step 1: Set baseline from rule's defaultConfidence for MEDIUM findings.
-        //         Respect explicit rule-level HIGH promotion (rule has more context than engine default).
-        //         Only cap LOW-default rules that accidentally emit MEDIUM/HIGH.
+        //         Respect explicit rule-level HIGH promotion from MEDIUM-default rules
+        //         (these have reliable evidence criteria like repo-target-match, flow-confirmed).
+        //         LOW-default rules are heuristic-heavy — their HIGH promotions stay capped.
         val baselined =
             when {
                 finding.confidence == Confidence.MEDIUM -> ceiling
-                finding.confidence == Confidence.HIGH -> Confidence.HIGH // rule explicitly promoted
+                finding.confidence == Confidence.HIGH && ceiling >= Confidence.MEDIUM -> Confidence.HIGH
                 finding.confidence.ordinal > ceiling.ordinal -> ceiling
                 else -> finding.confidence
             }


### PR DESCRIPTION
## Summary

Refinement of PR #107. The initial policy fix was too broad — it let HIGH promotions from LOW-default heuristic rules (unmemoized-recursion) pass through, inflating the HIGH tier with FPs.

**Fix**: Only MEDIUM-default and HIGH-default rules can promote to HIGH. LOW-default rules stay capped.

**Steekproef**: 15/15 HIGH findings verified as TPs across shopizer, fineract, openmrs.

| Repo | HIGH before refinement | HIGH after |
|------|----------------------|-----------|
| shopizer | 73 | 62 |
| cargotracker | 5 warnings | 2 (back to normal) |

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```