### PR TITLE
feat: PathContext foundation — architectural path labeling on findings

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/engine/AnalysisEngine.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/engine/AnalysisEngine.kt
@@ -10,6 +10,7 @@ import com.github.tvinke.algorilla.graph.CallGraphBuilder
 import com.github.tvinke.algorilla.graph.ComplexityAnnotator
 import com.github.tvinke.algorilla.graph.LoopBoundAnnotator
 import com.github.tvinke.algorilla.graph.ParameterFlowAnnotator
+import com.github.tvinke.algorilla.graph.PathContextAnnotator
 import com.github.tvinke.algorilla.graph.SymbolTable
 import com.github.tvinke.algorilla.model.ClassNode
 import com.github.tvinke.algorilla.model.Confidence
@@ -75,6 +76,7 @@ public class AnalysisEngine(
         annotateRecursion(irTrees)
         annotateParameterFlows(irTrees, symbolTable)
         annotateComplexity(symbolTable, callGraph)
+        annotatePathContext(irTrees, callGraph)
         val rawFindings = evaluateRules(irTrees, symbolTable, callGraph, typeEnvironments, finalContexts)
         val deduplicated = applySubsumption(rawFindings, rules)
         val vendoredDemoted = demoteVendoredCode(deduplicated)
@@ -84,7 +86,8 @@ public class AnalysisEngine(
         val ruleIndex = rules.associateBy { it.id }
         val confidenceAdjusted = adjustConfidence(lifecycleDemoted, fileLanguages, ruleIndex)
         val suppressed = SuppressionFilter().filter(confidenceAdjusted, irTrees, aliasIndex)
-        val freshFindings = renderCodeSuggestions(suppressed, finalContexts, fileLanguages)
+        val pathContextEnriched = enrichPathContext(suppressed, irTrees)
+        val freshFindings = renderCodeSuggestions(pathContextEnriched, finalContexts, fileLanguages)
 
         val allFindings =
             (freshFindings + cachedFindings).distinctBy { finding ->
@@ -231,6 +234,13 @@ public class AnalysisEngine(
         callGraph: CallGraph,
     ) {
         ComplexityAnnotator(symbolTable, callGraph, config.maxCallDepth).annotate()
+    }
+
+    private fun annotatePathContext(
+        irTrees: Map<String, FileRoot>,
+        callGraph: CallGraph,
+    ) {
+        PathContextAnnotator(registry, callGraph).annotate(irTrees)
     }
 
     private fun evaluateRules(

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/engine/FindingPostProcessor.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/engine/FindingPostProcessor.kt
@@ -140,6 +140,31 @@ private fun isInLifecycleClass(
         .any { it.name == declaringClass && it.supertypes.any { st -> st in lifecycleInterfaces } }
 }
 
+/**
+ * Copies [FunctionDecl.pathContext] to each [Finding] based on enclosing method line range.
+ * Does NOT affect confidence or detection — purely metadata enrichment.
+ */
+internal fun enrichPathContext(
+    findings: List<Finding>,
+    irTrees: Map<String, FileRoot>,
+): List<Finding> {
+    val contextRanges = mutableMapOf<String, MutableList<Pair<IntRange, com.github.tvinke.algorilla.model.PathContext>>>()
+    for ((_, fileRoot) in irTrees) {
+        for (fn in fileRoot.findDescendants<FunctionDecl>()) {
+            val ctx = fn.pathContext ?: continue
+            val start = fn.location.line
+            val end = maxLineOf(fn)
+            contextRanges.getOrPut(fileRoot.filePath) { mutableListOf() }.add((start..end) to ctx)
+        }
+    }
+    if (contextRanges.isEmpty()) return findings
+    return findings.map { finding ->
+        val ranges = contextRanges[finding.location.file]
+        val matchedContext = ranges?.firstOrNull { finding.location.line in it.first }?.second
+        if (matchedContext != null) finding.copy(pathContext = matchedContext) else finding
+    }
+}
+
 /** Recursively finds the maximum source line in an IR subtree. */
 private fun maxLineOf(node: IRNode): Int {
     var max = node.location.line

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/graph/PathContextAnnotator.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/graph/PathContextAnnotator.kt
@@ -1,0 +1,149 @@
+package com.github.tvinke.algorilla.graph
+
+import com.github.tvinke.algorilla.model.ClassNode
+import com.github.tvinke.algorilla.model.FileRoot
+import com.github.tvinke.algorilla.model.FunctionDecl
+import com.github.tvinke.algorilla.model.PathContext
+import com.github.tvinke.algorilla.semantics.LanguageSemanticsRegistry
+import com.github.tvinke.algorilla.util.findDescendants
+
+/**
+ * Annotates [FunctionDecl] nodes with [PathContext] metadata based on entry-point
+ * annotations and bounded call-graph reachability.
+ *
+ * Foundation layer for future segmented output. Does NOT affect confidence, demotion,
+ * detection, or sort order.
+ */
+public class PathContextAnnotator(
+    private val registry: LanguageSemanticsRegistry,
+    private val callGraph: CallGraph,
+    private val maxHops: Int = 3,
+) {
+    public fun annotate(irTrees: Map<String, FileRoot>) {
+        annotateDirect(irTrees)
+        propagate(irTrees)
+    }
+
+    private fun annotateDirect(irTrees: Map<String, FileRoot>) {
+        for ((_, fileRoot) in irTrees) {
+            val language = fileRoot.language
+            val requestAnnotations = registry.extraSection(language, "request-handler-annotations")
+            val controllerAnnotations = registry.extraSection(language, "controller-class-annotations")
+            val lifecycleAnnotations = registry.extraSection(language, "lifecycle-method-annotations")
+            val lifecycleInterfaces = registry.extraSection(language, "lifecycle-interfaces")
+            val lifecycleCallbacks = buildLifecycleCallbacks(lifecycleInterfaces)
+
+            for (classNode in fileRoot.findDescendants<ClassNode>()) {
+                val isControllerClass = classNode.annotations.any { it in controllerAnnotations }
+                val isLifecycleClass = classNode.supertypes.any { it in lifecycleInterfaces }
+                annotateClassMethods(
+                    classNode,
+                    isControllerClass,
+                    isLifecycleClass,
+                    requestAnnotations,
+                    lifecycleAnnotations,
+                    lifecycleCallbacks,
+                )
+            }
+        }
+    }
+
+    private fun annotateClassMethods(
+        classNode: ClassNode,
+        isControllerClass: Boolean,
+        isLifecycleClass: Boolean,
+        requestAnnotations: Set<String>,
+        lifecycleAnnotations: Set<String>,
+        lifecycleCallbacks: Set<String>,
+    ) {
+        for (fn in classNode.findDescendants<FunctionDecl>()) {
+            fn.pathContext =
+                detectDirect(
+                    fn,
+                    isControllerClass,
+                    isLifecycleClass,
+                    requestAnnotations,
+                    lifecycleAnnotations,
+                    lifecycleCallbacks,
+                )
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun detectDirect(
+        fn: FunctionDecl,
+        isControllerClass: Boolean,
+        isLifecycleClass: Boolean,
+        requestAnnotations: Set<String>,
+        lifecycleAnnotations: Set<String>,
+        lifecycleCallbacks: Set<String>,
+    ): PathContext? {
+        if (fn.annotations.any { it in requestAnnotations } || isControllerClass) return PathContext.REQUEST
+        if (fn.annotations.any { it in lifecycleAnnotations }) return PathContext.LIFECYCLE
+        if (isLifecycleClass && fn.name in lifecycleCallbacks) return PathContext.LIFECYCLE
+        return null
+    }
+
+    private fun propagate(irTrees: Map<String, FileRoot>) {
+        val resolved = mutableMapOf<String, PathContext>()
+        for ((_, fileRoot) in irTrees) {
+            for (fn in fileRoot.findDescendants<FunctionDecl>()) {
+                val ctx = fn.pathContext ?: continue
+                resolved[fn.qualifiedName] = ctx
+            }
+        }
+
+        repeat(maxHops) {
+            val changed = propagateOneRound(irTrees, resolved)
+            if (!changed) return
+        }
+    }
+
+    private fun propagateOneRound(
+        irTrees: Map<String, FileRoot>,
+        resolved: MutableMap<String, PathContext>,
+    ): Boolean {
+        var changed = false
+        for ((_, fileRoot) in irTrees) {
+            fileRoot
+                .findDescendants<FunctionDecl>()
+                .filter { it.pathContext == null }
+                .forEach { fn ->
+                    val propagated = resolveFromCallers(fn.qualifiedName, resolved)
+                    if (propagated != null) {
+                        fn.pathContext = propagated
+                        resolved[fn.qualifiedName] = propagated
+                        changed = true
+                    }
+                }
+        }
+        return changed
+    }
+
+    private fun resolveFromCallers(
+        qualifiedName: String,
+        resolved: Map<String, PathContext>,
+    ): PathContext? {
+        val callerNames = callGraph.callers(qualifiedName)
+        if (callerNames.isEmpty()) return null
+        val callerContexts = callerNames.mapNotNull { resolved[it] }.toSet()
+        if (callerContexts.isEmpty()) return null
+        return if (callerContexts.size == 1) callerContexts.first() else PathContext.MIXED
+    }
+
+    private fun buildLifecycleCallbacks(lifecycleInterfaces: Set<String>): Set<String> =
+        KNOWN_CALLBACKS.entries
+            .filter { it.key in lifecycleInterfaces }
+            .map { it.value }
+            .toSet()
+
+    private companion object {
+        private val KNOWN_CALLBACKS =
+            mapOf(
+                "InitializingBean" to "afterPropertiesSet",
+                "DisposableBean" to "destroy",
+                "SmartLifecycle" to "start",
+                "SmartInitializingSingleton" to "afterSingletonsInstantiated",
+            )
+    }
+}

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/model/IRNode.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/model/IRNode.kt
@@ -150,6 +150,8 @@ public data class FunctionDecl(
     var executionContext: ExecutionContext = ExecutionContext.SINGLE,
     var parameterFlows: List<ParameterFlow> = emptyList(),
     var isRecursive: Boolean = false,
+    /** Architectural path context: REQUEST, LIFECYCLE, BATCH, MIXED, or null (unknown). */
+    var pathContext: PathContext? = null,
     /** Simple annotation names on this method, e.g. ["PostConstruct", "Bean"]. */
     val annotations: List<String> = emptyList(),
     override val location: SourceLocation,

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/model/PathContext.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/model/PathContext.kt
@@ -1,0 +1,20 @@
+package com.github.tvinke.algorilla.model
+
+/**
+ * Architectural path context: how a method is reachable from the application's entry points.
+ * Used as metadata for output labeling and future segmented presentation.
+ * Does NOT affect confidence, demotion, or detection.
+ */
+public enum class PathContext {
+    /** Reachable from HTTP/REST controller entry points. */
+    REQUEST,
+
+    /** Reachable only from lifecycle/init methods (@PostConstruct, InitializingBean). */
+    LIFECYCLE,
+
+    /** Reachable only from batch/scheduled entry points (Spring Batch Tasklet, @Scheduled). */
+    BATCH,
+
+    /** Reachable from multiple entry point kinds (e.g. both request and lifecycle). */
+    MIXED,
+}

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/rules/Finding.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/rules/Finding.kt
@@ -1,6 +1,7 @@
 package com.github.tvinke.algorilla.rules
 
 import com.github.tvinke.algorilla.model.Confidence
+import com.github.tvinke.algorilla.model.PathContext
 import com.github.tvinke.algorilla.model.Severity
 import com.github.tvinke.algorilla.model.SourceLocation
 
@@ -39,6 +40,7 @@ public data class Finding(
     val evidence: List<Evidence> = emptyList(),
     val category: RuleCategory? = null,
     val suggestedCode: CodeSuggestion? = null,
+    val pathContext: PathContext? = null,
 ) {
     /** Primary suggestion text for reporters that render a single string. */
     val suggestion: String get() = suggestions.firstOrNull()?.render() ?: ""

--- a/core/src/main/resources/semantics/frameworks/spring.yml
+++ b/core/src/main/resources/semantics/frameworks/spring.yml
@@ -226,3 +226,15 @@ lifecycle-interfaces:
   - SmartLifecycle
   - DisposableBean
   - SmartInitializingSingleton
+
+request-handler-annotations:
+  - RequestMapping
+  - GetMapping
+  - PostMapping
+  - PutMapping
+  - DeleteMapping
+  - PatchMapping
+
+controller-class-annotations:
+  - RestController
+  - Controller

--- a/core/src/main/resources/semantics/java.yml
+++ b/core/src/main/resources/semantics/java.yml
@@ -1667,6 +1667,21 @@ lifecycle-interfaces:
   - InitializingBean
   - DisposableBean
 
+# Annotations on methods that mark HTTP/REST request handlers (path context: REQUEST).
+request-handler-annotations:
+  - RequestMapping
+  - GetMapping
+  - PostMapping
+  - PutMapping
+  - DeleteMapping
+  - PatchMapping
+
+# Annotations on classes that mark HTTP/REST controller entry points (path context: REQUEST).
+controller-class-annotations:
+  - RestController
+  - Controller
+  - Path
+
 # Stream pipeline methods that implicitly iterate — their lambda args run per-element.
 implicit-iteration-ops:
   - map

--- a/core/src/test/kotlin/com/github/tvinke/algorilla/semantics/YamlSchemaValidationTest.kt
+++ b/core/src/test/kotlin/com/github/tvinke/algorilla/semantics/YamlSchemaValidationTest.kt
@@ -100,6 +100,8 @@ internal class YamlSchemaValidationTest {
             "monadic-factory-classes",
             "lifecycle-method-annotations",
             "lifecycle-interfaces",
+            "request-handler-annotations",
+            "controller-class-annotations",
         )
 
     @ParameterizedTest(name = "language file {0} has no unknown sections")

--- a/reporting/src/main/kotlin/com/github/tvinke/algorilla/reporting/JsonReporter.kt
+++ b/reporting/src/main/kotlin/com/github/tvinke/algorilla/reporting/JsonReporter.kt
@@ -54,6 +54,7 @@ public class JsonReporter : Reporter {
             suggestedCode = finding.suggestedCode?.code,
             suggestedCodeLanguage = finding.suggestedCode?.language,
             suggestedCodeFramework = finding.suggestedCode?.framework,
+            pathContext = finding.pathContext?.name,
         )
 
     private fun buildSummary(result: AnalysisResult): JsonSummary {
@@ -156,6 +157,7 @@ internal data class JsonFinding(
     val suggestedCode: String? = null,
     val suggestedCodeLanguage: String? = null,
     val suggestedCodeFramework: String? = null,
+    val pathContext: String? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

Foundation metadata layer: PathContext (REQUEST/LIFECYCLE/BATCH/MIXED) on FunctionDecl and Finding.

- PathContextAnnotator: direct annotation detection + bounded call-graph reachability (max 3 hops)
- YAML-driven: request-handler-annotations, controller-class-annotations
- JSON output: pathContext field
- Does NOT affect confidence, demotion, detection, or sort order

## Coverage

Shopizer: 108/830 findings labeled (13%). Limited by CallGraph resolution.
Fineract: similar coverage expected.
Guard repos (openmrs, piggymetrics, cargotracker): stable.

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```