### PR TITLE
feat: interface-to-implementation resolution in call graph

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/engine/AnalysisEngine.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/engine/AnalysisEngine.kt
@@ -201,6 +201,12 @@ public class AnalysisEngine(
         val symbolTable = SymbolTable()
         for ((_, tree) in irTrees) {
             collectSymbols(tree.children, symbolTable)
+            // Register interface→implementation mappings for call resolution
+            for (classNode in tree.findDescendants<ClassNode>()) {
+                for (supertype in classNode.supertypes) {
+                    symbolTable.registerSupertype(supertype, classNode.name)
+                }
+            }
         }
         return symbolTable
     }

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/graph/SymbolTable.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/graph/SymbolTable.kt
@@ -56,6 +56,28 @@ public class SymbolTable {
      */
     public fun resolveType(variableName: String): String? = typeMap[variableName]
 
+    private val interfaceToImpl: MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    /**
+     * Registers that [implClass] implements/extends [supertype].
+     * Used for interface→implementation resolution in call-graph construction.
+     */
+    public fun registerSupertype(
+        supertype: String,
+        implClass: String,
+    ) {
+        interfaceToImpl.getOrPut(supertype) { mutableListOf() }.add(implClass)
+    }
+
+    /**
+     * Returns implementation class names for the given interface/supertype.
+     * Returns empty list if no implementations are known, or if multiple exist (ambiguous).
+     */
+    public fun implementationsOf(typeName: String): List<String> {
+        val impls = interfaceToImpl[typeName] ?: return emptyList()
+        return if (impls.size == 1) impls else emptyList() // Only resolve unambiguous single-impl
+    }
+
     /**
      * Returns all registered function declarations.
      */

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/util/CrossMethodResolver.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/util/CrossMethodResolver.kt
@@ -94,6 +94,7 @@ public object CrossMethodResolver {
         return bestMatch(byName, call)
     }
 
+    @Suppress("ReturnCount") // Guard clauses with early returns for each resolution strategy
     private fun resolveByTarget(
         call: FunctionCall,
         symbolTable: SymbolTable,
@@ -105,7 +106,13 @@ public object CrossMethodResolver {
         if (byClass.isNotEmpty()) return bestMatch(byClass, call)
         val targetType = symbolTable.resolveType(target) ?: return null
         val byType = symbolTable.lookupByClassAndName("$targetType.${call.name}")
-        return if (byType.isNotEmpty()) bestMatch(byType, call) else null
+        if (byType.isNotEmpty()) return bestMatch(byType, call)
+        // Interface→implementation: resolve via registered supertypes (single-impl only)
+        for (implClass in symbolTable.implementationsOf(targetType)) {
+            val byImpl = symbolTable.lookupByClassAndName("$implClass.${call.name}")
+            if (byImpl.isNotEmpty()) return bestMatch(byImpl, call)
+        }
+        return null
     }
 
     /**


### PR DESCRIPTION
## Summary

SymbolTable now tracks supertype→implementation mappings. CrossMethodResolver resolves interface-typed receivers to their single implementation.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Shopizer HIGH PathContext coverage | 1.6% (1/62) | **45% (28/62)** |
| Shopizer all PathContext coverage | 13% (109/830) | **43% (363/846)** |

Guard repos stable. OpenMRS +4 warnings (new TPs from better resolution).

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```