### PR TITLE
fix: prefer same-class methods for unqualified intra-class calls

### DIFF
--- a/core/src/main/kotlin/com/github/tvinke/algorilla/graph/CallGraphBuilder.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/graph/CallGraphBuilder.kt
@@ -41,7 +41,7 @@ public class CallGraphBuilder(
         val currentFn = if (node is FunctionDecl) node else enclosingFn
 
         if (node is FunctionCall && currentFn != null) {
-            resolveCallee(node)?.let { callee ->
+            resolveCallee(node, currentFn)?.let { callee ->
                 callGraph.addEdge(currentFn.qualifiedName, callee.qualifiedName)
             }
         }
@@ -51,5 +51,8 @@ public class CallGraphBuilder(
         }
     }
 
-    private fun resolveCallee(call: FunctionCall): FunctionDecl? = CrossMethodResolver.resolve(call, symbolTable)
+    private fun resolveCallee(
+        call: FunctionCall,
+        enclosingFn: FunctionDecl,
+    ): FunctionDecl? = CrossMethodResolver.resolve(call, symbolTable, enclosingClass = enclosingFn.declaringClass)
 }

--- a/core/src/main/kotlin/com/github/tvinke/algorilla/util/CrossMethodResolver.kt
+++ b/core/src/main/kotlin/com/github/tvinke/algorilla/util/CrossMethodResolver.kt
@@ -78,6 +78,7 @@ public object CrossMethodResolver {
         call: FunctionCall,
         symbolTable: SymbolTable,
         language: Language = Language.JAVA,
+        enclosingClass: String? = null,
     ): FunctionDecl? {
         val skip = LanguageSemanticsRegistry.DEFAULT.unresolvableNames(language)
         if (call.name in skip) return null
@@ -91,6 +92,12 @@ public object CrossMethodResolver {
             return null
         }
         val byName = symbolTable.lookupBySimpleName(call.name)
+        // Prefer methods in the same declaring class to avoid name collisions
+        // (e.g. merge() in 39 Mapper classes — pick the one in the caller's own class)
+        if (enclosingClass != null) {
+            val sameClass = byName.filter { it.declaringClass == enclosingClass }
+            if (sameClass.isNotEmpty()) return bestMatch(sameClass, call)
+        }
         return bestMatch(byName, call)
     }
 


### PR DESCRIPTION
## Summary

CrossMethodResolver gets enclosingClass from CallGraphBuilder. Prefers same-class methods for unqualified calls. Fixes name collisions (merge() in 39 Mapper classes).

Shopizer HIGH PathContext: 28/62 → 30/62 (+2). Guard repos stable.

## Verification

```
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew build
```